### PR TITLE
Improve $plugin_url and remove PHP notice

### DIFF
--- a/envato_setup/envato_setup.php
+++ b/envato_setup/envato_setup.php
@@ -47,8 +47,23 @@ if ( ! class_exists( 'Envato_Theme_Setup_Wizard' ) ) {
 		/** @var array Steps for the setup wizard */
 		protected $steps  = array();
 
-		/** @var string url for this plugin folder, used when enquing scripts */
-		protected $public_base_url = '';
+        /**
+		 * Relative plugin path
+		 *
+		 * @since 1.1.2
+		 *
+		 * @var string
+		 */
+		protected $plugin_path = '';
+
+		/**
+		 * Relative plugin url for this plugin folder, used when enquing scripts
+		 *
+		 * @since 1.1.2
+		 *
+		 * @var string
+		 */
+		protected $plugin_url = '';
 
 		/**
 		 * The slug name to refer to this menu
@@ -86,8 +101,9 @@ if ( ! class_exists( 'Envato_Theme_Setup_Wizard' ) ) {
 			$this->page_slug = apply_filters( $this->theme_name . '_theme_setup_wizard_page_slug', $this->theme_name.'-setup' );
 
 			//set relative plugin path url
-			$path = ltrim( end( @explode( get_template(), str_replace( '\\', '/', dirname( __FILE__ ) ) ) ), '/' );
-			$this->public_base_url = trailingslashit( trailingslashit( get_template_directory_uri() ) . $path );
+			$this->plugin_path = trailingslashit( $this->cleanFilePath( dirname( __FILE__ ) ) );
+            $relative_url = str_replace( $this->cleanFilePath( get_template_directory() ), '', $this->plugin_path );
+			$this->plugin_url = trailingslashit( get_template_directory_uri() . $relative_url );
 		}
 
 		/**
@@ -213,8 +229,8 @@ if ( ! class_exists( 'Envato_Theme_Setup_Wizard' ) ) {
 
 			$this->step = isset( $_GET['step'] ) ? sanitize_key( $_GET['step'] ) : current( array_keys( $this->steps ) );
 
-			wp_register_script( 'jquery-blockui', $this->public_base_url . '/js/jquery.blockUI.js', array( 'jquery' ), '2.70', true );
-			wp_register_script( 'envato-setup', $this->public_base_url . '/js/envato-setup.js', array( 'jquery', 'jquery-blockui' ), $this->version );
+			wp_register_script( 'jquery-blockui', $this->plugin_url . '/js/jquery.blockUI.js', array( 'jquery' ), '2.70', true );
+			wp_register_script( 'envato-setup', $this->plugin_url . '/js/envato-setup.js', array( 'jquery', 'jquery-blockui' ), $this->version );
 			wp_localize_script( 'envato-setup', 'envato_setup_params', array(
 				'tgm_plugin_nonce'            => array(
 				'update' => wp_create_nonce( 'tgmpa-update' ),
@@ -226,8 +242,8 @@ if ( ! class_exists( 'Envato_Theme_Setup_Wizard' ) ) {
 				'verify_text' => __( '...verifying','envato_setup' ),
 			) );
 
-			//wp_enqueue_style( 'envato_wizard_admin_styles', $this->public_base_url . '/css/admin.css', array(), $this->version );
-			wp_enqueue_style( 'envato-setup', $this->public_base_url . '/css/envato-setup.css', array( 'dashicons', 'install' ), $this->version );
+			//wp_enqueue_style( 'envato_wizard_admin_styles', $this->plugin_url . '/css/admin.css', array(), $this->version );
+			wp_enqueue_style( 'envato-setup', $this->plugin_url . '/css/envato-setup.css', array( 'dashicons', 'install' ), $this->version );
 
 			//enqueue style for admin notices
 			wp_enqueue_style( 'wp-admin' );
@@ -288,7 +304,7 @@ if ( ! class_exists( 'Envato_Theme_Setup_Wizard' ) ) {
 						'200px'
 					);
 				} else { ?>
-    					<img src="<?php echo $this->public_base_url; ?>/images/logo.png" alt="Envato install wizard" /><?php
+    					<img src="<?php echo $this->plugin_url; ?>/images/logo.png" alt="Envato install wizard" /><?php
 				} ?></a>
     		</h1>
     		<?php
@@ -1357,6 +1373,22 @@ if ( $show_link ) {
 		public function get_oauth_login_url( $return ) {
 			return $this->oauth_script . '?bounce_nonce=' . wp_create_nonce( 'envato_oauth_bounce_' . $this->envato_username ) . '&wp_return=' . urlencode( $return );
 		}
+
+        /**
+         * Helper function
+         * Take a path and return it clean
+         *
+         * @param string $path
+         *
+         * @since    1.1.2
+         */
+        public static function cleanFilePath( $path ) {
+            $path = str_replace( '', '', str_replace( array( "\\", "\\\\" ), '/', $path ) );
+            if ( $path[ strlen( $path ) - 1 ] === '/' ) {
+                $path = rtrim( $path, '/' );
+            }
+            return $path;
+        }
 	}
 
 }// if !class_exists


### PR DESCRIPTION
Some improvements to $plugin_url property:
- [x] Add `$plugin_path` property
- [x] Edit `$public_base_url` property name to `$plugin_url` for better code structure
- [x] Fix PHP notice: `Only variables should be passed by reference`.
- [x] Add `cleanFilePath` helper method
- [x] Fix activation redirect link
- [x] Add ability to move Wizard to submenu page (using ThemeTheck safe way)
